### PR TITLE
Dot notation to refer to nested objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,35 @@
 model
 =====
 
-Go data modeling
+Simple data modeling for Go.
+
+### Concepts
+
+  * Work with `map[string]interface{}` types holding raw data
+  * Bind many funcs to each field, each func gets called when `Do` is asked to process the underlying data.
+  * If the funcs return errors, they are collected and returned in a map of issues.
+  * Use dot notation to supported nested objects.
+
+ ### Example
+
+Given this model:
+
+```
+var Person = model.M{
+	"name":   {model.IsString, model.IsRequired},
+	"number": {model.IsNumber},
+	"ok":     {model.IsBool, model.IsRequired},
+	"tags":   {model.IsInterSlice},
+}
+```
+
+We can process some data provided by the user (perhaps from JSON):
+
+```
+var data map[string]interface{}
+json.Decode([]byte(`{
+	"name": "Mat",
+	"number": false,
+	"tags": [""],
+}`), &data)
+```

--- a/get.go
+++ b/get.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"log"
 	"strings"
 )
 
@@ -17,11 +18,11 @@ func Get(data map[string]interface{}, keypath string) interface{} {
 // keypath, or returns the second argument false if any of the data
 // is missing.
 func GetOK(data map[string]interface{}, keypath string) (interface{}, bool) {
-	segs := strings.Split(keypath, dot)
-	return getOK(data, segs)
+	return getOK(data, strings.Split(keypath, dot))
 }
 
 func getOK(data map[string]interface{}, keys []string) (interface{}, bool) {
+	log.Println("getOK", keys)
 	if len(keys) > 1 {
 		var sub interface{}
 		var ok bool

--- a/get.go
+++ b/get.go
@@ -1,0 +1,39 @@
+package model
+
+import (
+	"strings"
+)
+
+const dot = "."
+
+// Get gets the value from the data by the given dot-notation
+// keypath. Returns nil if any of the data is missing.
+func Get(data map[string]interface{}, keypath string) interface{} {
+	value, _ := GetOK(data, keypath)
+	return value
+}
+
+// GetOK gets the value from the data by the given dot-notation
+// keypath, or returns the second argument false if any of the data
+// is missing.
+func GetOK(data map[string]interface{}, keypath string) (interface{}, bool) {
+	segs := strings.Split(keypath, dot)
+	return getOK(data, segs)
+}
+
+func getOK(data map[string]interface{}, keys []string) (interface{}, bool) {
+	if len(keys) > 1 {
+		var sub interface{}
+		var ok bool
+		if sub, ok = data[keys[0]]; !ok {
+			return nil, false
+		}
+		var submap map[string]interface{}
+		if submap, ok = sub.(map[string]interface{}); !ok {
+			return nil, false
+		}
+		return getOK(submap, keys[1:])
+	}
+	value, ok := data[keys[0]]
+	return value, ok
+}

--- a/get_test.go
+++ b/get_test.go
@@ -1,0 +1,64 @@
+package model_test
+
+import (
+	"testing"
+
+	"github.com/cheekybits/is"
+	"github.com/cheekybits/model"
+)
+
+func TestGet(t *testing.T) {
+	is := is.New(t)
+
+	for _, test := range []struct {
+		M   map[string]interface{}
+		K   string
+		Exp interface{}
+		OK  bool
+	}{
+		{
+			map[string]interface{}{"name": "Tylor"},
+			"name",
+			"Tylor",
+			true,
+		},
+		{
+			map[string]interface{}{"address": map[string]interface{}{"city": "London"}},
+			"address.city",
+			"London",
+			true,
+		},
+		{
+			map[string]interface{}{
+				"address": map[string]interface{}{
+					"postcode": map[string]interface{}{
+						"inner": "NG19",
+					},
+				},
+			},
+			"address.postcode.inner",
+			"NG19",
+			true,
+		},
+		{
+			nil,
+			"address.postcode.inner",
+			nil,
+			false,
+		},
+		{
+			map[string]interface{}{"address": map[string]interface{}{"city": "London"}},
+			"address.country",
+			nil,
+			false,
+		},
+	} {
+
+		actual, actualOK := model.GetOK(test.M, test.K)
+
+		is.Equal(actual, test.Exp)
+		is.Equal(actualOK, test.OK)
+
+	}
+
+}

--- a/model.go
+++ b/model.go
@@ -9,14 +9,13 @@ const (
 	nonFieldPrefix = "__"
 	keyBefore      = nonFieldPrefix + "before"
 	keyAfter       = nonFieldPrefix + "after"
-	dot            = "."
 )
 
 // Errs is a slice of error keyed by the field name.
 type Errs map[string][]error
 
 // f is the validator function type.
-type f func(data map[string]interface{}, key string) error
+type f func(data map[string]interface{}, keypath string) error
 
 // M is a map providing []F functions for each field.
 type M map[string][]f
@@ -39,6 +38,7 @@ func (m M) Do(data map[string]interface{}) (map[string]interface{}, Errs) {
 
 	for k := range m {
 		if strings.HasPrefix(k, nonFieldPrefix) {
+			// skip all __ fields
 			continue
 		}
 		for _, fn := range m[k] {

--- a/model.go
+++ b/model.go
@@ -9,6 +9,7 @@ const (
 	nonFieldPrefix = "__"
 	keyBefore      = nonFieldPrefix + "before"
 	keyAfter       = nonFieldPrefix + "after"
+	dot            = "."
 )
 
 // Errs is a slice of error keyed by the field name.

--- a/model_test.go
+++ b/model_test.go
@@ -178,14 +178,14 @@ func TestNestedData(t *testing.T) {
 	}
 	_, errs = m.Do(d)
 	is.Equal(len(errs), 2)
-	is.Equal(errs["address.inner"][0], "should be string")
-	is.Equal(errs["address.outer"][0], "should be string")
+	is.Equal(errs["address.postcode.inner"][0].Error(), "must be string")
+	is.Equal(errs["address.postcode.outer"][0].Error(), "must be string")
 
 	d = map[string]interface{}{
 		"address": map[string]interface{}{},
 	}
 	_, errs = m.Do(d)
 	is.Equal(len(errs), 1)
-	is.Equal(errs["address.postcode"][0], "is required")
+	is.Equal(errs["address.postcode"][0].Error(), "is required")
 
 }

--- a/model_test.go
+++ b/model_test.go
@@ -1,7 +1,9 @@
 package model_test
 
 import (
+	"encoding/json"
 	"errors"
+	"log"
 	"testing"
 
 	"github.com/cheekybits/is"
@@ -13,6 +15,27 @@ var fokcalls = 0
 func fok(data map[string]interface{}, key string) error {
 	fokcalls++
 	return nil
+}
+
+func TestExample(t *testing.T) {
+
+	var Person = model.M{
+		"name":   {model.IsString, model.IsRequired},
+		"number": {model.IsNumber},
+		"ok":     {model.IsBool, model.IsRequired},
+		"tags":   {model.IsInterfaceSlice},
+	}
+
+	var data map[string]interface{}
+	json.Unmarshal([]byte(`{
+		"name": 123,
+		"number": false,
+		"tags": ["one", "two", "three"],
+	}`), &data)
+
+	_, errs := Person.Do(data)
+	log.Println(errs)
+
 }
 
 func TestModel(t *testing.T) {

--- a/model_test.go
+++ b/model_test.go
@@ -147,3 +147,45 @@ func TestModelAfter(t *testing.T) {
 	is.Equal(errs["model"][0].Error(), "whoops")
 
 }
+
+func TestNestedData(t *testing.T) {
+	is := is.New(t)
+
+	m := model.M{
+		"address.postcode":       {model.IsRequired},
+		"address.postcode.inner": {model.IsString},
+		"address.postcode.outer": {model.IsString},
+	}
+
+	d := map[string]interface{}{
+		"address": map[string]interface{}{
+			"postcode": map[string]interface{}{
+				"inner": "NG1",
+				"outer": "8BC",
+			},
+		},
+	}
+	_, errs := m.Do(d)
+	is.Equal(len(errs), 0)
+
+	d = map[string]interface{}{
+		"address": map[string]interface{}{
+			"postcode": map[string]interface{}{
+				"inner": 123,
+				"outer": 456,
+			},
+		},
+	}
+	_, errs = m.Do(d)
+	is.Equal(len(errs), 2)
+	is.Equal(errs["address.inner"][0], "should be string")
+	is.Equal(errs["address.outer"][0], "should be string")
+
+	d = map[string]interface{}{
+		"address": map[string]interface{}{},
+	}
+	_, errs = m.Do(d)
+	is.Equal(len(errs), 1)
+	is.Equal(errs["address.postcode"][0], "is required")
+
+}

--- a/types.go
+++ b/types.go
@@ -485,3 +485,27 @@ func IsUintptrSlice(data map[string]interface{}, keypath string) error {
 	}
 	return nil
 }
+
+// //go:generate genny -pkg="model" -in=$GOFILE -out=types.go gen "interface{}=BUILTINS"
+
+// IsInterface checks to make sure the value is a interface{}.
+// Remains silent if the data is not present.
+func IsInterface(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
+		if _, ok := v.(interface{}); !ok {
+			return errors.New("must be interface{}")
+		}
+	}
+	return nil
+}
+
+// IsInterfaceSlice checks to make sure the value is a interface{}.
+// Remains silent if the data is not present.
+func IsInterfaceSlice(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
+		if _, ok := v.([]interface{}); !ok {
+			return errors.New("must be array of interface{}")
+		}
+	}
+	return nil
+}

--- a/types.go
+++ b/types.go
@@ -6,12 +6,14 @@ package model
 
 import "errors"
 
+// //go:generate genny -pkg="model" -in=$GOFILE -out=types.go gen "bool=BUILTINS"
+
 // IsBool checks to make sure the value is a bool.
 // Remains silent if the data is not present.
-func IsBool(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsBool(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.(bool); !ok {
-			return errors.New(key + " must be bool")
+			return errors.New("must be bool")
 		}
 	}
 	return nil
@@ -19,21 +21,23 @@ func IsBool(data map[string]interface{}, key string) error {
 
 // IsBoolSlice checks to make sure the value is a bool.
 // Remains silent if the data is not present.
-func IsBoolSlice(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsBoolSlice(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.([]bool); !ok {
-			return errors.New(key + " must be array of bool")
+			return errors.New("must be array of bool")
 		}
 	}
 	return nil
 }
 
+// //go:generate genny -pkg="model" -in=$GOFILE -out=types.go gen "byte=BUILTINS"
+
 // IsByte checks to make sure the value is a byte.
 // Remains silent if the data is not present.
-func IsByte(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsByte(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.(byte); !ok {
-			return errors.New(key + " must be byte")
+			return errors.New("must be byte")
 		}
 	}
 	return nil
@@ -41,21 +45,23 @@ func IsByte(data map[string]interface{}, key string) error {
 
 // IsByteSlice checks to make sure the value is a byte.
 // Remains silent if the data is not present.
-func IsByteSlice(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsByteSlice(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.([]byte); !ok {
-			return errors.New(key + " must be array of byte")
+			return errors.New("must be array of byte")
 		}
 	}
 	return nil
 }
 
+// //go:generate genny -pkg="model" -in=$GOFILE -out=types.go gen "complex128=BUILTINS"
+
 // IsComplex128 checks to make sure the value is a complex128.
 // Remains silent if the data is not present.
-func IsComplex128(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsComplex128(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.(complex128); !ok {
-			return errors.New(key + " must be complex128")
+			return errors.New("must be complex128")
 		}
 	}
 	return nil
@@ -63,21 +69,23 @@ func IsComplex128(data map[string]interface{}, key string) error {
 
 // IsComplex128Slice checks to make sure the value is a complex128.
 // Remains silent if the data is not present.
-func IsComplex128Slice(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsComplex128Slice(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.([]complex128); !ok {
-			return errors.New(key + " must be array of complex128")
+			return errors.New("must be array of complex128")
 		}
 	}
 	return nil
 }
 
+// //go:generate genny -pkg="model" -in=$GOFILE -out=types.go gen "complex64=BUILTINS"
+
 // IsComplex64 checks to make sure the value is a complex64.
 // Remains silent if the data is not present.
-func IsComplex64(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsComplex64(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.(complex64); !ok {
-			return errors.New(key + " must be complex64")
+			return errors.New("must be complex64")
 		}
 	}
 	return nil
@@ -85,21 +93,23 @@ func IsComplex64(data map[string]interface{}, key string) error {
 
 // IsComplex64Slice checks to make sure the value is a complex64.
 // Remains silent if the data is not present.
-func IsComplex64Slice(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsComplex64Slice(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.([]complex64); !ok {
-			return errors.New(key + " must be array of complex64")
+			return errors.New("must be array of complex64")
 		}
 	}
 	return nil
 }
 
+// //go:generate genny -pkg="model" -in=$GOFILE -out=types.go gen "error=BUILTINS"
+
 // IsError checks to make sure the value is a error.
 // Remains silent if the data is not present.
-func IsError(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsError(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.(error); !ok {
-			return errors.New(key + " must be error")
+			return errors.New("must be error")
 		}
 	}
 	return nil
@@ -107,21 +117,23 @@ func IsError(data map[string]interface{}, key string) error {
 
 // IsErrorSlice checks to make sure the value is a error.
 // Remains silent if the data is not present.
-func IsErrorSlice(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsErrorSlice(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.([]error); !ok {
-			return errors.New(key + " must be array of error")
+			return errors.New("must be array of error")
 		}
 	}
 	return nil
 }
 
+// //go:generate genny -pkg="model" -in=$GOFILE -out=types.go gen "float32=BUILTINS"
+
 // IsFloat32 checks to make sure the value is a float32.
 // Remains silent if the data is not present.
-func IsFloat32(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsFloat32(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.(float32); !ok {
-			return errors.New(key + " must be float32")
+			return errors.New("must be float32")
 		}
 	}
 	return nil
@@ -129,21 +141,23 @@ func IsFloat32(data map[string]interface{}, key string) error {
 
 // IsFloat32Slice checks to make sure the value is a float32.
 // Remains silent if the data is not present.
-func IsFloat32Slice(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsFloat32Slice(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.([]float32); !ok {
-			return errors.New(key + " must be array of float32")
+			return errors.New("must be array of float32")
 		}
 	}
 	return nil
 }
 
+// //go:generate genny -pkg="model" -in=$GOFILE -out=types.go gen "float64=BUILTINS"
+
 // IsFloat64 checks to make sure the value is a float64.
 // Remains silent if the data is not present.
-func IsFloat64(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsFloat64(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.(float64); !ok {
-			return errors.New(key + " must be float64")
+			return errors.New("must be float64")
 		}
 	}
 	return nil
@@ -151,21 +165,23 @@ func IsFloat64(data map[string]interface{}, key string) error {
 
 // IsFloat64Slice checks to make sure the value is a float64.
 // Remains silent if the data is not present.
-func IsFloat64Slice(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsFloat64Slice(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.([]float64); !ok {
-			return errors.New(key + " must be array of float64")
+			return errors.New("must be array of float64")
 		}
 	}
 	return nil
 }
 
+// //go:generate genny -pkg="model" -in=$GOFILE -out=types.go gen "int=BUILTINS"
+
 // IsInt checks to make sure the value is a int.
 // Remains silent if the data is not present.
-func IsInt(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsInt(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.(int); !ok {
-			return errors.New(key + " must be int")
+			return errors.New("must be int")
 		}
 	}
 	return nil
@@ -173,21 +189,23 @@ func IsInt(data map[string]interface{}, key string) error {
 
 // IsIntSlice checks to make sure the value is a int.
 // Remains silent if the data is not present.
-func IsIntSlice(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsIntSlice(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.([]int); !ok {
-			return errors.New(key + " must be array of int")
+			return errors.New("must be array of int")
 		}
 	}
 	return nil
 }
 
+// //go:generate genny -pkg="model" -in=$GOFILE -out=types.go gen "int16=BUILTINS"
+
 // IsInt16 checks to make sure the value is a int16.
 // Remains silent if the data is not present.
-func IsInt16(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsInt16(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.(int16); !ok {
-			return errors.New(key + " must be int16")
+			return errors.New("must be int16")
 		}
 	}
 	return nil
@@ -195,21 +213,23 @@ func IsInt16(data map[string]interface{}, key string) error {
 
 // IsInt16Slice checks to make sure the value is a int16.
 // Remains silent if the data is not present.
-func IsInt16Slice(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsInt16Slice(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.([]int16); !ok {
-			return errors.New(key + " must be array of int16")
+			return errors.New("must be array of int16")
 		}
 	}
 	return nil
 }
 
+// //go:generate genny -pkg="model" -in=$GOFILE -out=types.go gen "int32=BUILTINS"
+
 // IsInt32 checks to make sure the value is a int32.
 // Remains silent if the data is not present.
-func IsInt32(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsInt32(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.(int32); !ok {
-			return errors.New(key + " must be int32")
+			return errors.New("must be int32")
 		}
 	}
 	return nil
@@ -217,21 +237,23 @@ func IsInt32(data map[string]interface{}, key string) error {
 
 // IsInt32Slice checks to make sure the value is a int32.
 // Remains silent if the data is not present.
-func IsInt32Slice(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsInt32Slice(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.([]int32); !ok {
-			return errors.New(key + " must be array of int32")
+			return errors.New("must be array of int32")
 		}
 	}
 	return nil
 }
 
+// //go:generate genny -pkg="model" -in=$GOFILE -out=types.go gen "int64=BUILTINS"
+
 // IsInt64 checks to make sure the value is a int64.
 // Remains silent if the data is not present.
-func IsInt64(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsInt64(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.(int64); !ok {
-			return errors.New(key + " must be int64")
+			return errors.New("must be int64")
 		}
 	}
 	return nil
@@ -239,21 +261,23 @@ func IsInt64(data map[string]interface{}, key string) error {
 
 // IsInt64Slice checks to make sure the value is a int64.
 // Remains silent if the data is not present.
-func IsInt64Slice(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsInt64Slice(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.([]int64); !ok {
-			return errors.New(key + " must be array of int64")
+			return errors.New("must be array of int64")
 		}
 	}
 	return nil
 }
 
+// //go:generate genny -pkg="model" -in=$GOFILE -out=types.go gen "int8=BUILTINS"
+
 // IsInt8 checks to make sure the value is a int8.
 // Remains silent if the data is not present.
-func IsInt8(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsInt8(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.(int8); !ok {
-			return errors.New(key + " must be int8")
+			return errors.New("must be int8")
 		}
 	}
 	return nil
@@ -261,21 +285,23 @@ func IsInt8(data map[string]interface{}, key string) error {
 
 // IsInt8Slice checks to make sure the value is a int8.
 // Remains silent if the data is not present.
-func IsInt8Slice(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsInt8Slice(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.([]int8); !ok {
-			return errors.New(key + " must be array of int8")
+			return errors.New("must be array of int8")
 		}
 	}
 	return nil
 }
 
+// //go:generate genny -pkg="model" -in=$GOFILE -out=types.go gen "rune=BUILTINS"
+
 // IsRune checks to make sure the value is a rune.
 // Remains silent if the data is not present.
-func IsRune(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsRune(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.(rune); !ok {
-			return errors.New(key + " must be rune")
+			return errors.New("must be rune")
 		}
 	}
 	return nil
@@ -283,21 +309,23 @@ func IsRune(data map[string]interface{}, key string) error {
 
 // IsRuneSlice checks to make sure the value is a rune.
 // Remains silent if the data is not present.
-func IsRuneSlice(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsRuneSlice(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.([]rune); !ok {
-			return errors.New(key + " must be array of rune")
+			return errors.New("must be array of rune")
 		}
 	}
 	return nil
 }
 
+// //go:generate genny -pkg="model" -in=$GOFILE -out=types.go gen "string=BUILTINS"
+
 // IsString checks to make sure the value is a string.
 // Remains silent if the data is not present.
-func IsString(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsString(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.(string); !ok {
-			return errors.New(key + " must be string")
+			return errors.New("must be string")
 		}
 	}
 	return nil
@@ -305,21 +333,23 @@ func IsString(data map[string]interface{}, key string) error {
 
 // IsStringSlice checks to make sure the value is a string.
 // Remains silent if the data is not present.
-func IsStringSlice(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsStringSlice(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.([]string); !ok {
-			return errors.New(key + " must be array of string")
+			return errors.New("must be array of string")
 		}
 	}
 	return nil
 }
 
+// //go:generate genny -pkg="model" -in=$GOFILE -out=types.go gen "uint=BUILTINS"
+
 // IsUint checks to make sure the value is a uint.
 // Remains silent if the data is not present.
-func IsUint(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsUint(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.(uint); !ok {
-			return errors.New(key + " must be uint")
+			return errors.New("must be uint")
 		}
 	}
 	return nil
@@ -327,21 +357,23 @@ func IsUint(data map[string]interface{}, key string) error {
 
 // IsUintSlice checks to make sure the value is a uint.
 // Remains silent if the data is not present.
-func IsUintSlice(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsUintSlice(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.([]uint); !ok {
-			return errors.New(key + " must be array of uint")
+			return errors.New("must be array of uint")
 		}
 	}
 	return nil
 }
 
+// //go:generate genny -pkg="model" -in=$GOFILE -out=types.go gen "uint16=BUILTINS"
+
 // IsUint16 checks to make sure the value is a uint16.
 // Remains silent if the data is not present.
-func IsUint16(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsUint16(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.(uint16); !ok {
-			return errors.New(key + " must be uint16")
+			return errors.New("must be uint16")
 		}
 	}
 	return nil
@@ -349,21 +381,23 @@ func IsUint16(data map[string]interface{}, key string) error {
 
 // IsUint16Slice checks to make sure the value is a uint16.
 // Remains silent if the data is not present.
-func IsUint16Slice(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsUint16Slice(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.([]uint16); !ok {
-			return errors.New(key + " must be array of uint16")
+			return errors.New("must be array of uint16")
 		}
 	}
 	return nil
 }
 
+// //go:generate genny -pkg="model" -in=$GOFILE -out=types.go gen "uint32=BUILTINS"
+
 // IsUint32 checks to make sure the value is a uint32.
 // Remains silent if the data is not present.
-func IsUint32(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsUint32(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.(uint32); !ok {
-			return errors.New(key + " must be uint32")
+			return errors.New("must be uint32")
 		}
 	}
 	return nil
@@ -371,21 +405,23 @@ func IsUint32(data map[string]interface{}, key string) error {
 
 // IsUint32Slice checks to make sure the value is a uint32.
 // Remains silent if the data is not present.
-func IsUint32Slice(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsUint32Slice(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.([]uint32); !ok {
-			return errors.New(key + " must be array of uint32")
+			return errors.New("must be array of uint32")
 		}
 	}
 	return nil
 }
 
+// //go:generate genny -pkg="model" -in=$GOFILE -out=types.go gen "uint64=BUILTINS"
+
 // IsUint64 checks to make sure the value is a uint64.
 // Remains silent if the data is not present.
-func IsUint64(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsUint64(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.(uint64); !ok {
-			return errors.New(key + " must be uint64")
+			return errors.New("must be uint64")
 		}
 	}
 	return nil
@@ -393,21 +429,23 @@ func IsUint64(data map[string]interface{}, key string) error {
 
 // IsUint64Slice checks to make sure the value is a uint64.
 // Remains silent if the data is not present.
-func IsUint64Slice(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsUint64Slice(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.([]uint64); !ok {
-			return errors.New(key + " must be array of uint64")
+			return errors.New("must be array of uint64")
 		}
 	}
 	return nil
 }
 
+// //go:generate genny -pkg="model" -in=$GOFILE -out=types.go gen "uint8=BUILTINS"
+
 // IsUint8 checks to make sure the value is a uint8.
 // Remains silent if the data is not present.
-func IsUint8(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsUint8(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.(uint8); !ok {
-			return errors.New(key + " must be uint8")
+			return errors.New("must be uint8")
 		}
 	}
 	return nil
@@ -415,21 +453,23 @@ func IsUint8(data map[string]interface{}, key string) error {
 
 // IsUint8Slice checks to make sure the value is a uint8.
 // Remains silent if the data is not present.
-func IsUint8Slice(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsUint8Slice(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.([]uint8); !ok {
-			return errors.New(key + " must be array of uint8")
+			return errors.New("must be array of uint8")
 		}
 	}
 	return nil
 }
 
+// //go:generate genny -pkg="model" -in=$GOFILE -out=types.go gen "uintptr=BUILTINS"
+
 // IsUintptr checks to make sure the value is a uintptr.
 // Remains silent if the data is not present.
-func IsUintptr(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsUintptr(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.(uintptr); !ok {
-			return errors.New(key + " must be uintptr")
+			return errors.New("must be uintptr")
 		}
 	}
 	return nil
@@ -437,10 +477,10 @@ func IsUintptr(data map[string]interface{}, key string) error {
 
 // IsUintptrSlice checks to make sure the value is a uintptr.
 // Remains silent if the data is not present.
-func IsUintptrSlice(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsUintptrSlice(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		if _, ok := v.([]uintptr); !ok {
-			return errors.New(key + " must be array of uintptr")
+			return errors.New("must be array of uintptr")
 		}
 	}
 	return nil

--- a/types_gen.go
+++ b/types_gen.go
@@ -1,6 +1,6 @@
 package model
 
-// //go:generate genny -pkg="model" -in=$GOFILE -out=types.go gen "Type=BUILTINS"
+// //go:generate genny -pkg="model" -in=$GOFILE -out=types.go gen "Type=BUILTINS,interface{}"
 
 import (
 	"errors"

--- a/types_gen.go
+++ b/types_gen.go
@@ -2,33 +2,33 @@ package model
 
 // //go:generate genny -pkg="model" -in=$GOFILE -out=types.go gen "Type=BUILTINS"
 
-// import (
-// 	"errors"
+import (
+	"errors"
 
-// 	"github.com/cheekybits/genny/generic"
-// )
+	"github.com/cheekybits/genny/generic"
+)
 
-// // Type is the generic type placeholder.
-// type Type generic.Type
+// Type is the generic type placeholder.
+type Type generic.Type
 
-// // IsType checks to make sure the value is a Type.
-// // Remains silent if the data is not present.
-// func IsType(data map[string]interface{}, key string) error {
-// 	if v, ok := data[key]; ok {
-// 		if _, ok := v.(Type); !ok {
-// 			return errors.New(key + " must be Type")
-// 		}
-// 	}
-// 	return nil
-// }
+// IsType checks to make sure the value is a Type.
+// Remains silent if the data is not present.
+func IsType(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
+		if _, ok := v.(Type); !ok {
+			return errors.New("must be Type")
+		}
+	}
+	return nil
+}
 
-// // IsTypeSlice checks to make sure the value is a Type.
-// // Remains silent if the data is not present.
-// func IsTypeSlice(data map[string]interface{}, key string) error {
-// 	if v, ok := data[key]; ok {
-// 		if _, ok := v.([]Type); !ok {
-// 			return errors.New(key + " must be array of Type")
-// 		}
-// 	}
-// 	return nil
-// }
+// IsTypeSlice checks to make sure the value is a Type.
+// Remains silent if the data is not present.
+func IsTypeSlice(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
+		if _, ok := v.([]Type); !ok {
+			return errors.New("must be array of Type")
+		}
+	}
+	return nil
+}

--- a/validators.go
+++ b/validators.go
@@ -2,8 +2,8 @@ package model
 
 import (
 	"encoding/json"
-
 	"errors"
+	"log"
 )
 
 var errRequired = errors.New("is required")
@@ -14,6 +14,7 @@ func IsRequired(data map[string]interface{}, keypath string) error {
 	var v interface{}
 	var ok bool
 	if v, ok = GetOK(data, keypath); !ok {
+		log.Println(keypath, "not found")
 		return errRequired
 	}
 	if v == nil {

--- a/validators.go
+++ b/validators.go
@@ -10,10 +10,10 @@ var errRequired = errors.New("is required")
 
 // IsRequired checks to make sure key is present and the value
 // is non-nil.
-func IsRequired(data map[string]interface{}, key string) error {
+func IsRequired(data map[string]interface{}, keypath string) error {
 	var v interface{}
 	var ok bool
-	if v, ok = data[key]; !ok {
+	if v, ok = GetOK(data, keypath); !ok {
 		return errRequired
 	}
 	if v == nil {
@@ -48,8 +48,8 @@ var errNotNumber = errors.New("must be a number")
 
 // IsNumber checks to make sure the value is a number.
 // Remains silent if the data is not present.
-func IsNumber(data map[string]interface{}, key string) error {
-	if v, ok := data[key]; ok {
+func IsNumber(data map[string]interface{}, keypath string) error {
+	if v, ok := GetOK(data, keypath); ok {
 		switch v.(type) {
 		case int, int8, int16, int32, int64,
 			uint, uint8, uint16, uint32, uint64,


### PR DESCRIPTION
- Dot notation can now peer inside other `map[string]interface{}` types
- Added `Get` and `GetOK` helpers for people writing their own functions that need to access via a key path.
